### PR TITLE
[sc-107258] fix: resolve the endpoint correctly when setting the s3 region.

### DIFF
--- a/client.go
+++ b/client.go
@@ -48,9 +48,10 @@ func (r *resolverV2) ResolveEndpoint(ctx context.Context, params s3.EndpointPara
 	smithyendpoints.Endpoint,
 	error,
 ) {
-	params.Endpoint = aws.String(r.BaseEndpoint)
 	if r.Region != "" {
 		params.Region = aws.String(r.Region)
+	} else {
+		params.Endpoint = aws.String(r.BaseEndpoint)
 	}
 	return s3.NewDefaultEndpointResolverV2().ResolveEndpoint(ctx, params)
 }


### PR DESCRIPTION
This PR fixes the following error:

```
[2024/09/05 15:59:06] [error] Failed to process file: log-test4.log from S3 bucket 'caly-tester': operation error S3: GetObject, resolve auth scheme: resolve endpoint: endpoint rule error, Custom endpoint `` was not a valid URI
```